### PR TITLE
Let angular continue if bugsnag lib fails to load

### DIFF
--- a/src/scripts/angular-bugsnag.js
+++ b/src/scripts/angular-bugsnag.js
@@ -8,9 +8,14 @@
             $provide.provider({
                 bugsnag: function () {
 
-                    if (typeof Bugsnag === 'undefined') {
-                        var Bugsnag = {};
-                    }
+                    // if a script blocker blocks the bugsnag library Bugsnag will be undefined at this point, so we initialize it to an object
+                    // with methods that do nothing but are declared and won't throw errors later by the angular-bugsnag
+                    // module calling them
+                    var Bugsnag = window.Bugsnag || {
+                        notifyException: function () {},
+                        notify: function () {},
+                        noConflict: function () {}
+                    };
 
                     _bugsnag = Bugsnag;
                     var _self = this;

--- a/src/scripts/angular-bugsnag.js
+++ b/src/scripts/angular-bugsnag.js
@@ -7,6 +7,11 @@
         .config(['$provide', function ($provide) {
             $provide.provider({
                 bugsnag: function () {
+
+                    if (typeof Bugsnag === 'undefined') {
+                        var Bugsnag = {};
+                    }
+
                     _bugsnag = Bugsnag;
                     var _self = this;
                     var _beforeNotify;


### PR DESCRIPTION
when the bugsnag library fails to load (in my case, uBlock Origin is blocking it), this will allow angular to not brick when injecting its providers.