### PR TITLE
Add jasmine-core to development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "gulp-uglify": "^1.1.0",
         "gulp-useref": "^1.1.1",
         "gulp-util": "^3.0.3",
+        "jasmine-core": "^2.4.1",
         "jshint-stylish": "^1.0.0",
         "karma": "^0.12.31",
         "karma-chrome-launcher": "^0.1.7",


### PR DESCRIPTION
I downloaded this repo, and ran `make` but it failed with the following error:

```
[13:30:01] Error: Cannot find module 'jasmine-core'
  at Function.Module._resolveFilename (module.js:325:15)
  at Function.require.resolve (internal/module.js:16:19)
```

This change adds `jasmine-core` to the development dependencies so the `make` command will work on systems that don't have `jasmine-core` installed globally.
